### PR TITLE
Docker incorrect .NET version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,11 +10,9 @@ WORKDIR /src
 
 # copy everything and restore
 COPY ["BeeJet.Bot/BeeJet.Bot.csproj", "BeeJet.Bot/"]
-# COPY "BeeJet.Bot/*" "BeeJet.Bot/"
 RUN dotnet restore "BeeJet.Bot/BeeJet.Bot.csproj"
 
 COPY ["BeeJet.Web/BeeJet.Web.csproj", "BeeJet.Web/"]
-# COPY "BeeJet.Web/*" "BeeJet.Web/"
 RUN dotnet restore "BeeJet.Web/BeeJet.Web.csproj"
 
 COPY . .


### PR DESCRIPTION
Base images were set to 7.0 but projects were lowered to 6.0
Container cannot start with wrong version