### PR TITLE
Change join buttons to use db for link to game instead of regex

### DIFF
--- a/BeeJet.Bot/BeeJetBot.cs
+++ b/BeeJet.Bot/BeeJetBot.cs
@@ -58,6 +58,7 @@ namespace BeeJet.Bot
                 .AddSingleton(_logger)
                 .AddSingleton(_repository)
                 .AddSingleton(serviceProvider => _repository.EchoMessageDb.Value)
+                .AddSingleton(serviceProvider => _repository.ButtonContextDb.Value)
                 .AddSingleton(serviceProvider => new SteamAPIService(options.SteamAPIKey))
                 .AddSingleton(serviceProvider => new IGDBService(options.IDGBClientId, options.IDGBClientSecret));
 

--- a/BeeJet.Bot/Commands/Handlers/GameManagement/AddGameCommandHandler.cs
+++ b/BeeJet.Bot/Commands/Handlers/GameManagement/AddGameCommandHandler.cs
@@ -15,7 +15,7 @@ namespace BeeJet.Bot.Commands.Handlers.GameManagement
         private readonly IGDBService _igdbService;
         private readonly IButtonContextDb _buttonContextDb;
 
-        public AddGameCommandHandler(IGDBService igdbService, IButtonContextDb buttonContextDb)
+        public AddGameCommandHandler(IGDBService igdbService, IButtonContextDb buttonContextDb = null)
         {
             _igdbService = igdbService;
             _buttonContextDb = buttonContextDb;

--- a/BeeJet.Bot/Commands/Handlers/GameManagement/AddGameCommandHandler.cs
+++ b/BeeJet.Bot/Commands/Handlers/GameManagement/AddGameCommandHandler.cs
@@ -79,11 +79,11 @@ namespace BeeJet.Bot.Commands.Handlers.GameManagement
             {
                 categoryChannel = await CreateCategoryChannelAsync(categoryName, context);
             }
-
-            await AddToGameListChannelAsync(game, categoryChannel, gameInfoEmbed, context);
-
+            
             var channel = await context.Guild.CreateTextChannelAsync(game.Trim().Replace(" ", "-"), (properties) => properties.CategoryId = categoryChannel.Id);
             await context.SlashCommandInteraction.RespondAsync($"Channel created", ephemeral: true);
+            
+            await AddToGameListChannelAsync(game, categoryChannel, gameInfoEmbed, context, channel);
 
             var permissionOverrides = new OverwritePermissions(viewChannel: PermValue.Deny);
             await channel.AddPermissionOverwriteAsync(context.Guild.EveryoneRole, permissionOverrides);
@@ -101,7 +101,7 @@ namespace BeeJet.Bot.Commands.Handlers.GameManagement
             return (await context.Guild.GetChannelsAsync()).OfType<ICategoryChannel>().FirstOrDefault(channel => channel.Name.Equals(categoryName, StringComparison.OrdinalIgnoreCase));
         }
 
-        private async Task AddToGameListChannelAsync(string game, ICategoryChannel categoryChannel, EmbedBuilder gameInfoEmbed, SlashCommandContext context)
+        private async Task AddToGameListChannelAsync(string game, ICategoryChannel categoryChannel, EmbedBuilder gameInfoEmbed, SlashCommandContext context, ITextChannel gameChannel)
         {
             var gameListChannel = await AddOrGetGameListChannelAsync(categoryChannel, context);
             var builder = new ComponentBuilder()
@@ -109,8 +109,8 @@ namespace BeeJet.Bot.Commands.Handlers.GameManagement
                 .WithButton("Leave", LeaveButtonId, ButtonStyle.Danger);
 
             var usermesage = await gameListChannel.SendMessageAsync($"Click to join channel for {game}", embed: gameInfoEmbed?.Build(), components: builder.Build());
-            _buttonContextDb?.CreateNewButtonContext(usermesage.Id, JointButtonId, game);
-            _buttonContextDb?.CreateNewButtonContext(usermesage.Id, LeaveButtonId, game);
+            _buttonContextDb?.CreateNewButtonContext(usermesage.Id, JointButtonId, gameChannel.Id.ToString());
+            _buttonContextDb?.CreateNewButtonContext(usermesage.Id, LeaveButtonId, gameChannel.Id.ToString());
         }
 
         private EmbedBuilder CreateGameInfoEmbed(GameInfo gameInfo)

--- a/BeeJet.Bot/Commands/Handlers/GameManagement/GameButtonsPressedHandler.cs
+++ b/BeeJet.Bot/Commands/Handlers/GameManagement/GameButtonsPressedHandler.cs
@@ -1,15 +1,23 @@
 ﻿using Discord.WebSocket;
 using Discord;
 using System.Text.RegularExpressions;
+using BeeJet.Storage.Interfaces;
 
 namespace BeeJet.Bot.Commands.Handlers.GameManagement
 {
     public class GameButtonsPressedHandler : ButtonPressedHandler
     {
+        private IButtonContextDb _buttonContextDb;
+
+        public GameButtonsPressedHandler(IButtonContextDb buttonContextDb)
+        {
+            _buttonContextDb = buttonContextDb;
+        }
+
         [ButtonPressedHandler(AddGameCommandHandler.JointButtonId)]
         public async Task JoinGamePressed()
         {
-            if (TryGetGameName(Context.Message, out string gameName))
+            if (TryGetGameName(Context.Message, AddGameCommandHandler.JointButtonId, out string gameName))
             {
                 await JoinGameAsync(gameName);
             }
@@ -38,7 +46,7 @@ namespace BeeJet.Bot.Commands.Handlers.GameManagement
         [ButtonPressedHandler(AddGameCommandHandler.LeaveButtonId)]
         public async Task LeaveGamePressed()
         {
-            if (TryGetGameName(Context.Message, out string gameName))
+            if (TryGetGameName(Context.Message, AddGameCommandHandler.LeaveButtonId, out string gameName))
             {
                 ITextChannel gameChannel = GetGameChannel(Context.Message, gameName);
                 if (gameChannel != null)
@@ -51,25 +59,26 @@ namespace BeeJet.Bot.Commands.Handlers.GameManagement
             await Context.ComponentInteraction.DeferAsync();
         }
 
-        private static bool TryGetGameName(IUserMessage message, out string gameName)
+        private bool TryGetGameName(IUserMessage message, string customButtonId, out string gameName)
         {
-            var regex = new Regex(@"Click to join channel for ([a-zA-Z0-9\s]*)", RegexOptions.Compiled);
-
-            var matching = regex.Match(message.Content);
-            if (matching.Success)
+            var context = _buttonContextDb.GetButtonContextForMessageIdAndCustomId(message.Id, customButtonId);
+            if (context == null)
             {
-                gameName = matching.Groups[1].Value.Trim().Replace(" ", "-");
+                gameName = null;
+                return false;
+            }
+            else
+            {
+                gameName = (string)context.HandlerContext;
                 return true;
             }
-            gameName = null;
-            return false;
         }
 
         private static SocketTextChannel GetGameChannel(IUserMessage message, string gameName)
         {
             var socketMessageChannel = message.Channel as SocketTextChannel;
             var textChannels = socketMessageChannel.Guild.Channels.OfType<SocketTextChannel>();
-            var gameChannel = textChannels.FirstOrDefault(channel => channel.Name.Equals(gameName, StringComparison.OrdinalIgnoreCase) && channel.CategoryId == socketMessageChannel.CategoryId);
+            var gameChannel = textChannels.FirstOrDefault(channel => channel.Name.Equals(gameName.Replace(" ", "-"), StringComparison.OrdinalIgnoreCase) && channel.CategoryId == socketMessageChannel.CategoryId);
             return gameChannel;
         }
     }

--- a/BeeJet.Bot/Commands/Handlers/Steam/SteamButtonsPressedHandler.cs
+++ b/BeeJet.Bot/Commands/Handlers/Steam/SteamButtonsPressedHandler.cs
@@ -2,42 +2,48 @@
 using Discord;
 using System.Text.RegularExpressions;
 using BeeJet.Bot.Commands.Handlers.GameManagement;
+using BeeJet.Storage.Interfaces;
 
 namespace BeeJet.Bot.Commands.Handlers.Steam
 {
     public class SteamButtonsPressedHandler : ButtonPressedHandler
     {
 
+        private IButtonContextDb _buttonContextDb;
+
+        public SteamButtonsPressedHandler(IButtonContextDb buttonContextDb)
+        {
+            _buttonContextDb = buttonContextDb;
+        }
+
         [ButtonPressedHandler("join-game-id-", startsWith: true)]
         public async Task JoinGamePressed()
         {
-            if (TryParseButtonCustomId(out string gameName, out string category))
+            if (GetChannelId(out ulong channelId))
             {
-                var channel = GetGameChannel(Context.Message, gameName, category);
-                await GameButtonsPressedHandler.GivePermissionToJoinChannel(Context.User, channel);
+                var channel = await Context.Client.GetChannelAsync(channelId);
+                if (channel is ITextChannel textChannel)
+                {
+                    await GameButtonsPressedHandler.GivePermissionToJoinChannel(Context.User, textChannel);
+                }
             }
             await Context.ComponentInteraction.DeferAsync(true);
         }
 
-        private bool TryParseButtonCustomId(out string gameName, out string category)
+        private bool GetChannelId(out ulong channelId)
         {
-            var match = new Regex("join-game-id-([a-zA-Z0-9\\s]*)-------([a-zA-Z0-9-\\s]*)", RegexOptions.Compiled).Match(Context.ComponentInteraction.Data.CustomId);
-            if (!match.Success)
+            var context = _buttonContextDb.GetButtonContextForMessageIdAndCustomId(Context.Message.Id, Context.ComponentInteraction.Data.CustomId);
+            if (context == null)
             {
-                gameName = null;
-                category = null;
+                channelId = 0;
                 return false;
             }
-            gameName = match.Groups[1].Value;
-            category = match.Groups[2].Value;
-            return true;
+            else
+            {
+                channelId = ulong.Parse((string)context.HandlerContext);//LiteDb doesn't support ulong
+                return true;
+            }
         }
-
-        private static SocketTextChannel GetGameChannel(IUserMessage message, string gameName, string categoryName)
-        {
-            var textChannels = ((SocketTextChannel)message.Channel).Guild.Channels.OfType<SocketTextChannel>();
-            var gameChannel = textChannels.FirstOrDefault(channel => channel.Name.Equals(gameName, StringComparison.OrdinalIgnoreCase) && channel.Category.Name == categoryName.Replace("-", " "));
-            return gameChannel;
-        }
+     
     }
 }

--- a/BeeJet.Storage/Databases/ButtonContextDb.cs
+++ b/BeeJet.Storage/Databases/ButtonContextDb.cs
@@ -1,0 +1,46 @@
+﻿using BeeJet.Storage.Entities;
+using BeeJet.Storage.Interfaces;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BeeJet.Storage.Databases
+{
+    internal class ButtonContextDb : BaseDb<IButtonContext, ButtonContext>, IButtonContextDb
+    {
+        public ButtonContextDb(ILiteDatabase database)
+            : base(database)
+        {
+        }
+
+        protected override void EnsureIndexes()
+        {
+            Collection.EnsureIndex(b => b.Id);
+            Collection.EnsureIndex(b => b.MessageId);
+        }
+
+        public void CreateNewButtonContext(ulong messageId, string customIdButton, object context)
+        {
+            var buttonContext = Create();
+            buttonContext.MessageId = messageId;
+            buttonContext.CustomButtonId = customIdButton;
+            buttonContext.HandlerContext = context;
+            Add(buttonContext);
+        }
+
+        public ICollection<IButtonContext> GetButtonContextsForMessageId(ulong messageId)
+        {
+            return Collection.Query().Where(b => b.MessageId == messageId).ToList().OfType<IButtonContext>().ToList();
+        }
+
+
+        protected override string ProvideCollectionName() => "buttoncontexts";
+
+        public IButtonContext GetButtonContextForMessageIdAndCustomId(ulong messageId, string customButtonId)
+        {
+            return Collection.Query().Where(b => b.MessageId == messageId && b.CustomButtonId == customButtonId).FirstOrDefault();
+        }
+    }
+}

--- a/BeeJet.Storage/Entities/ButtonContext.cs
+++ b/BeeJet.Storage/Entities/ButtonContext.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using BeeJet.Storage.Interfaces;
+
+namespace BeeJet.Storage.Entities
+{
+    internal class ButtonContext : IButtonContext
+    {
+        public int Id { get; set; }
+        public ulong MessageId { get; set; }
+        public string CustomButtonId { get; set; }
+        public object? HandlerContext { get; set; }
+    }
+}

--- a/BeeJet.Storage/Entities/ButtonContext.cs
+++ b/BeeJet.Storage/Entities/ButtonContext.cs
@@ -11,7 +11,7 @@ namespace BeeJet.Storage.Entities
     {
         public int Id { get; set; }
         public ulong MessageId { get; set; }
-        public string CustomButtonId { get; set; }
+        public string CustomButtonId { get; set; } = "";
         public object? HandlerContext { get; set; }
     }
 }

--- a/BeeJet.Storage/Interfaces/IBeeJetRepository.cs
+++ b/BeeJet.Storage/Interfaces/IBeeJetRepository.cs
@@ -3,5 +3,6 @@
     public interface IBeeJetRepository
     {
         Lazy<IEchoMessageDb> EchoMessageDb { get; }
+        Lazy<IButtonContextDb> ButtonContextDb { get; }
     }
 }

--- a/BeeJet.Storage/Interfaces/IButtonContext.cs
+++ b/BeeJet.Storage/Interfaces/IButtonContext.cs
@@ -1,0 +1,10 @@
+﻿namespace BeeJet.Storage.Interfaces
+{
+    public interface IButtonContext
+    {
+        public int Id { get; set; }
+        public ulong MessageId { get; set; }
+        public string CustomButtonId { get; set; }
+        public object? HandlerContext { get; set; }
+    }
+}

--- a/BeeJet.Storage/Interfaces/IButtonContextDb.cs
+++ b/BeeJet.Storage/Interfaces/IButtonContextDb.cs
@@ -1,0 +1,9 @@
+﻿namespace BeeJet.Storage.Interfaces
+{
+    public interface IButtonContextDb
+    {
+        void CreateNewButtonContext(ulong messageId, string customIdButton, object context);
+        IButtonContext GetButtonContextForMessageIdAndCustomId(ulong id, string customButtonId);
+        ICollection<IButtonContext> GetButtonContextsForMessageId(ulong messageId);
+    }
+}

--- a/BeeJet.Storage/Repositories/BeeJetRepository.cs
+++ b/BeeJet.Storage/Repositories/BeeJetRepository.cs
@@ -13,5 +13,6 @@ namespace BeeJet.Storage.Repositories
         }
 
         public Lazy<IEchoMessageDb> EchoMessageDb => new Lazy<IEchoMessageDb>(() => new EchoMessageDb(_database));
+        public Lazy<IButtonContextDb> ButtonContextDb => new Lazy<IButtonContextDb>(() => new ButtonContextDb(_database));
     }
 }

--- a/BeeJet.Tests/AddGameCommandHandlerTests.cs
+++ b/BeeJet.Tests/AddGameCommandHandlerTests.cs
@@ -17,7 +17,7 @@ namespace BeeJet.Tests
             var guild = GuildFixture.GuildWithAdminRole;
 
             var service = Substitute.For<IGDBService>(string.Empty, string.Empty);
-            var commandHandler = new AddGameCommandHandler(service);
+            var commandHandler = new AddGameCommandHandler(service, null);
 
             var commandInteraction = Substitute.For<ISlashCommandInteraction>();
             var client = Substitute.For<IDiscordClient>();
@@ -52,7 +52,7 @@ namespace BeeJet.Tests
             categoryChannel.Guild.Returns(guild);
 
             var service = Substitute.For<IGDBService>(string.Empty, string.Empty);
-            var commandHandler = new AddGameCommandHandler(service);
+            var commandHandler = new AddGameCommandHandler(service, null);
             var commandInteraction = Substitute.For<ISlashCommandInteraction>();
             var client = Substitute.For<IDiscordClient>();
           
@@ -75,7 +75,7 @@ namespace BeeJet.Tests
             var user = UserFixture.UserWithAdminRole;
 
             var service = Substitute.For<IGDBService>(string.Empty, string.Empty);
-            var commandHandler = new AddGameCommandHandler(service);
+            var commandHandler = new AddGameCommandHandler(service, null);
             var commandInteraction = Substitute.For<ISlashCommandInteraction>();
             var client = Substitute.For<IDiscordClient>();
 
@@ -95,7 +95,7 @@ namespace BeeJet.Tests
 
             var builder = new SlashCommandBuilder();
             var service = Substitute.For<IGDBService>(string.Empty, string.Empty);
-            var commandHandler = new AddGameCommandHandler(service);
+            var commandHandler = new AddGameCommandHandler(service, null);
             commandHandler.RegisterOptions(builder);
             var properties = builder.Build();
 

--- a/BeeJet.Tests/AddGameCommandHandlerTests.cs
+++ b/BeeJet.Tests/AddGameCommandHandlerTests.cs
@@ -17,7 +17,7 @@ namespace BeeJet.Tests
             var guild = GuildFixture.GuildWithAdminRole;
 
             var service = Substitute.For<IGDBService>(string.Empty, string.Empty);
-            var commandHandler = new AddGameCommandHandler(service, null);
+            var commandHandler = new AddGameCommandHandler(service);
 
             var commandInteraction = Substitute.For<ISlashCommandInteraction>();
             var client = Substitute.For<IDiscordClient>();
@@ -52,7 +52,7 @@ namespace BeeJet.Tests
             categoryChannel.Guild.Returns(guild);
 
             var service = Substitute.For<IGDBService>(string.Empty, string.Empty);
-            var commandHandler = new AddGameCommandHandler(service, null);
+            var commandHandler = new AddGameCommandHandler(service);
             var commandInteraction = Substitute.For<ISlashCommandInteraction>();
             var client = Substitute.For<IDiscordClient>();
           
@@ -75,7 +75,7 @@ namespace BeeJet.Tests
             var user = UserFixture.UserWithAdminRole;
 
             var service = Substitute.For<IGDBService>(string.Empty, string.Empty);
-            var commandHandler = new AddGameCommandHandler(service, null);
+            var commandHandler = new AddGameCommandHandler(service);
             var commandInteraction = Substitute.For<ISlashCommandInteraction>();
             var client = Substitute.For<IDiscordClient>();
 
@@ -95,7 +95,7 @@ namespace BeeJet.Tests
 
             var builder = new SlashCommandBuilder();
             var service = Substitute.For<IGDBService>(string.Empty, string.Empty);
-            var commandHandler = new AddGameCommandHandler(service, null);
+            var commandHandler = new AddGameCommandHandler(service);
             commandHandler.RegisterOptions(builder);
             var properties = builder.Build();
 


### PR DESCRIPTION
Use db for storing the channelId of the gamechannel the join button is for.
Is reusable for other buttons, because buttoncontext is of type object it can also store other type of contexts.

LiteDb doesn't support ulong, so it is converted to string. Also it doesn't support generics for stored object, so no generic property for context exists.